### PR TITLE
makepanda and build changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -200,4 +200,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_11_0_arm64.whl
-          gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_11_0_x86_64.whl
+          gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_10_9_x86_64.whl
+          gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_10_9_universal2.whl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,9 +180,24 @@ jobs:
             --python-incdir="$pythonLocation/include" \
             --python-libdir="$pythonLocation/lib"
             
+          arch -x86_64 python makepanda/makepanda.py \
+            --wheel \
+            --threads=4 \
+            --everything \
+            --use-toontown \
+
+          # universal
+          python makepanda/makepanda.py \
+            --wheel \
+            --threads=4 \
+            --everything \
+            --use-toontown \
+            --universal
+
 
       - name: Upload Panda Binary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_11_0_arm64.whl
+          gh release upload ${{ github.ref_name }} panda3d-1.11.0-cp311-cp311-macosx_11_0_x86_64.whl

--- a/makepanda/makepanda.py
+++ b/makepanda/makepanda.py
@@ -821,11 +821,14 @@ if (COMPILER=="GCC"):
         PkgDisable("COCOA")
 
     if GetTarget() == 'darwin':
+        # this is no longer maintained and honestly hard to get on modern systems, 
+        # plus tt doesn't need it and we dont plan to add shaders
+        # lets disable it
+        PkgDisable("NVIDIACG")
         if OSX_ARCHS and 'x86_64' not in OSX_ARCHS and 'i386' not in OSX_ARCHS:
             # These support only these archs, so don't build them if we're not
             # targeting any of the supported archs.
             PkgDisable("FMODEX")
-            PkgDisable("NVIDIACG")
         elif OSX_ARCHS and 'arm64' in OSX_ARCHS:
             # We must be using the 11.0 SDK or higher, so can't build FMOD Ex
             if not PkgSkip("FMODEX"):


### PR DESCRIPTION
- makepanda: disable nvidia cg toolkit on mac as its outdated and no longer maintained
- build: Build 3 separate builds for x86_64, arm64, and universal, so  user has a choice